### PR TITLE
GITLAB-951 Improve gauge reporting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.11.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.elasticsearch</groupId>
             <artifactId>elasticsearch</artifactId>
             <version>${elasticsearch.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -82,9 +82,10 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.dropwizard.metrics</groupId>
-            <artifactId>metrics-core</artifactId>
-            <version>3.2.6</version>
+            <groupId>com.carrotsearch.randomizedtesting</groupId>
+            <artifactId>randomizedtesting-runner</artifactId>
+            <version>${randomized.testrunner.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -95,6 +96,23 @@
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-module-afterburner</artifactId>
             <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-core</artifactId>
+            <version>3.2.6</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.hamcrest</groupId>
+                    <artifactId>hamcrest-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.lucene</groupId>
@@ -116,33 +134,15 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.carrotsearch.randomizedtesting</groupId>
-            <artifactId>randomizedtesting-runner</artifactId>
-            <version>${randomized.testrunner.version}</version>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <version>1.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <version>1.7.19</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.12</version>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.hamcrest</groupId>
-                    <artifactId>hamcrest-core</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-all</artifactId>
-            <version>1.3</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/com/linagora/elasticsearch/metrics/ElasticsearchReporter.java
+++ b/src/main/java/com/linagora/elasticsearch/metrics/ElasticsearchReporter.java
@@ -300,11 +300,9 @@ public class ElasticsearchReporter extends ScheduledReporter {
             AtomicInteger entriesWritten = new AtomicInteger(0);
 
             for (Map.Entry<String, Gauge> entry : gauges.entrySet()) {
-                if (entry.getValue().getValue() != null) {
-                    JsonMetric<? extends Metric> jsonMetric = new JsonGauge(name(prefix, entry.getKey()), timestamp, entry.getValue());
-                    connection = writeJsonMetricAndRecreateConnectionIfNeeded(jsonMetric, connection, entriesWritten);
-                    addJsonMetricToPercolationIfMatching(jsonMetric, percolationMetrics);
-                }
+                JsonMetric<? extends Metric> jsonMetric = new JsonGauge(name(prefix, entry.getKey()), timestamp, entry.getValue());
+                connection = writeJsonMetricAndRecreateConnectionIfNeeded(jsonMetric, connection, entriesWritten);
+                addJsonMetricToPercolationIfMatching(jsonMetric, percolationMetrics);
             }
 
             for (Map.Entry<String, Counter> entry : counters.entrySet()) {

--- a/src/test/java/com/linagora/elasticsearch/metrics/ElasticsearchReporterTest.java
+++ b/src/test/java/com/linagora/elasticsearch/metrics/ElasticsearchReporterTest.java
@@ -237,6 +237,16 @@ public class ElasticsearchReporterTest extends ESIntegTestCase {
     }
 
     @Test
+    public void nullGaugeShouldNotBeReported() {
+        registry.register(name("foo", "bar"), (Gauge<Integer>) () -> null);
+
+        elasticsearchReporter.report();
+
+        assertThatThrownBy(() -> client().prepareSearch(indexWithDate).setTypes("metrics").execute().actionGet())
+            .isInstanceOf(IndexNotFoundException.class);
+    }
+
+    @Test
     public void testThatSpecifyingSeveralHostsWork() throws Exception {
         elasticsearchReporter = createElasticsearchReporterBuilder().hosts("localhost:10000", "localhost:" + getPortOfRunningNode()).build();
 

--- a/src/test/java/com/linagora/elasticsearch/metrics/MetricsElasticsearchModuleTest.java
+++ b/src/test/java/com/linagora/elasticsearch/metrics/MetricsElasticsearchModuleTest.java
@@ -1,20 +1,19 @@
 package com.linagora.elasticsearch.metrics;
 
-import java.util.HashSet;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
 
 import com.codahale.metrics.Gauge;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.linagora.elasticsearch.metrics.MetricsElasticsearchModule;
+import com.google.common.collect.ImmutableSet;
 import com.linagora.elasticsearch.metrics.JsonMetrics.JsonGauge;
 import com.linagora.elasticsearch.metrics.JsonMetrics.JsonMetric;
-
-import static org.junit.Assert.*;
 
 /**
  * Tests if value is an array.
@@ -23,30 +22,16 @@ import static org.junit.Assert.*;
  */
 public class MetricsElasticsearchModuleTest {
 	@Test
-	public void test() throws JsonProcessingException {
+	public void test() {
 		ObjectMapper objectMapper = new ObjectMapper();
 		objectMapper.registerModule(new MetricsElasticsearchModule(TimeUnit.MINUTES, TimeUnit.MINUTES, "@timestamp", null));
 		
-		Gauge<String> gaugeString = new Gauge<String>() {
-			@Override
-			public String getValue() {
-				return "STRING VALUE";
-			}
-		};
+		Gauge<String> gaugeString = () -> "STRING VALUE";
 		
 		/**
 		 * Used for deadlocks in metrics-jvm ThreadStatesGaugeSet.class.
 		 */
-		Gauge<Set<String>> gaugeStringSet = new Gauge<Set<String>>() {
-			@Override
-			public Set<String> getValue() {
-				HashSet<String> testSet = new HashSet<>();
-				testSet.add("1");
-				testSet.add("2");
-				testSet.add("3");
-				return testSet;
-			}
-		};
+		Gauge<Set<String>> gaugeStringSet = () -> ImmutableSet.of("1", "2", "3");
 		
 		
 		JsonMetric<?> jsonMetricString = new JsonGauge("string", Long.MAX_VALUE, gaugeString);


### PR DESCRIPTION
## Why

 - Gauge value is read 2 times:
   - One time for a null check
   - A second time for the metric reporting

 - A failing gauge crashes the all metric reporting

Errors are handled for the metric serialization but not upon the null check (!!).

## How

Removing the null check solves these issue.

Upon null value we index a document with a null field.

## Connex changes

This PR carries a few index/warning fixes/ common best practice changes, issued in separated commits.

This PR is related to https://github.com/linagora/james-project/pull/2005 : it is its counter part, handled as part of this library...